### PR TITLE
Allowing the use of the HTML api

### DIFF
--- a/Model/Queue/Handler/Handler.php
+++ b/Model/Queue/Handler/Handler.php
@@ -97,7 +97,13 @@ class Handler
         $url = $this->webhook->getUrlPath();
         $model_name = $this->webhook->getModelName();
 
-        $page = $this->json->unserialize($this->pageService->fetchContentApi($url, $model_name), true);
+        if( str_contains($this->webhook->getWebhookData(), "{{widget") ) {
+            $api = PageService::API_QWIK_PAGE_ENDPOINT;
+        } else {
+            $api = PageService::API_HTML_PAGE_ENDPOINT;
+        }
+
+        $page = $this->json->unserialize($this->pageService->fetchContentApi($url, $api), true);
 
         try {
             $contentPage = $this->contentPageRepository->findByBuilderioPageId($page['id']);

--- a/Service/BuilderIO/Page.php
+++ b/Service/BuilderIO/Page.php
@@ -34,7 +34,9 @@ class Page
         'data.Keywords'
     ];
 
-    protected const API_PAGE_ENDPOINT = 'https://cdn.builder.io/api/v1/qwik/';
+    public const API_QWIK_PAGE_ENDPOINT = 'https://cdn.builder.io/api/v1/qwik/page';
+
+    public const API_HTML_PAGE_ENDPOINT = 'https://cdn.builder.io/api/v3/html/page';
 
     /**
      * Page constructor.
@@ -56,14 +58,15 @@ class Page
      * Fetch content from the Builder.io API for a given URL.
      *
      * @param string $url The URL to fetch content for.
+     * @param string $api The API endpoint to use (default is the HTML page endpoint).
      * @return mixed The content fetched from the API or an empty string on failure.
      * @throws GuzzleException If an error occurs during the request.
      */
-    public function fetchContentApi($url, $model = 'page'): mixed
+    public function fetchContentApi($url, $api = self::API_HTML_PAGE_ENDPOINT): mixed
     {
         $content = '';
         $apiResult = $this->builderIO->getRequest(
-            self::API_PAGE_ENDPOINT . $model,
+            $api,
             [
             'url' => $url,
             'limit' => 1,


### PR DESCRIPTION
This pull request introduces changes to dynamically select the appropriate API endpoint for fetching content based on webhook data and improves the flexibility of the `PageService` class. The most important updates include adding new constants for API endpoints, modifying the `fetchContentApi` method to accept an API endpoint parameter, and updating the logic in the `processPage` function to determine the endpoint dynamically.

### Dynamic API Endpoint Selection:

* `Service/BuilderIO/Page.php`:
  - Added two new public constants, `API_QWIK_PAGE_ENDPOINT` and `API_HTML_PAGE_ENDPOINT`, to define distinct API endpoints for Qwik and HTML page content.
  - Updated the `fetchContentApi` method to accept an `api` parameter, defaulting to the HTML page endpoint, allowing greater flexibility in API requests.

* `Model/Queue/Handler/Handler.php`:
  - Updated the `processPage` function to dynamically select the API endpoint based on the presence of `{{widget` in the webhook data, ensuring the correct endpoint is used for different content types.